### PR TITLE
docs: 为 0_create_agent 和 1_todo 增加中文解释文档

### DIFF
--- a/docs/0_create_agent.md
+++ b/docs/0_create_agent.md
@@ -1,0 +1,91 @@
+# 0_create_agent 笔记
+
+这是整个课程的**第零课（入门课）**，目标是介绍 LangChain 预构建的 **ReAct Agent** 抽象，为后续构建"深度 Agent"打基础。内容分为四大块：
+
+## 1. 什么是 ReAct Agent
+
+ReAct = **Re**asoning + **Act**ing，源自论文 *ReAct: Synergizing Reasoning and Acting in Language Models*。
+
+一个 ReAct Agent 由三个部分组成：
+- **LLM**（大语言模型）
+- **Tools**（工具集）
+- **Prompt**（系统提示词）
+
+运行机制是一个**循环**：LLM 查看上下文 -> 决定是否调用工具 -> 调用工具 -> 接收工具返回的结果（observation）-> 继续推理或结束。循环直到 LLM 认为不需要再调用工具为止。
+
+## 2. 用工具构建 Agent（基础版）
+
+Notebook 用一个 `calculator` 工具做演示：
+
+```python
+@tool
+def calculator(operation, a, b):
+    # 支持 add/subtract/multiply/divide
+```
+
+然后用 `create_agent()` 创建 agent：
+
+```python
+agent = create_agent(model, tools, system_prompt=SYSTEM_PROMPT)
+```
+
+底层会编译成一个 LangGraph 的 `CompiledStateGraph`，包含两个节点：**LLM 节点** 和 **ToolNode**（工具执行节点）。
+
+调用示例：用户问 "What is 3.1 * 4.2?"，LLM 生成一个带 `tool_calls` 的 `AIMessage`，ToolNode 执行计算返回 `ToolMessage`，LLM 再组织最终回答。
+
+> 注意：`create_react_agent` 在 LangChain 1.0 中已被移到 `langchain` 包并重命名为 `create_agent`。
+
+## 3. 图、状态与消息（Graph, State, Messages）
+
+默认使用的状态是 `AgentState`，核心就是一个 `messages` 列表：
+
+```python
+class AgentState(TypedDict):
+    messages: Annotated[Sequence[BaseMessage], add_messages]
+    remaining_steps: NotRequired[RemainingSteps]
+```
+
+- `add_messages` 是 reducer，负责把新消息追加到列表末尾
+- `remaining_steps` 跟踪图的递归步数
+
+## 4. 在工具中访问和修改状态（重点）
+
+这是本节最核心的进阶内容，分三步讲解：
+
+### a) 自定义 State
+
+扩展 `AgentState`，增加一个 `ops` 字段记录所有运算历史：
+
+```python
+class CalcState(AgentState):
+    ops: Annotated[List[str], reduce_list]
+```
+
+### b) 注入状态（InjectedState）
+
+工具需要访问 state，但 LLM 不知道 state 的存在。解决方案是用 `InjectedState` 注解，让 ToolNode 在执行时自动注入：
+
+```python
+def calculator_wstate(
+    operation, a, b,
+    state: Annotated[CalcState, InjectedState],        # LLM 看不到这个参数
+    tool_call_id: Annotated[str, InjectedToolCallId],  # LLM 也看不到
+):
+```
+
+### c) 用 Command 更新状态
+
+工具不再直接返回值，而是返回 `Command` 对象，同时更新 `ops` 和 `messages`：
+
+```python
+return Command(update={
+    "ops": [f"({operation}, {a}, {b}),"],
+    "messages": [ToolMessage(f"{result}", tool_call_id=tool_call_id)]
+})
+```
+
+最后还演示了**并行工具调用**的场景：计算 `3.1 * 4.2 + 5.5 * 6.5` 时，LLM 在一轮中同时发出两个 multiply 调用，ToolNode 并行执行，然后 LLM 再发一个 add 调用汇总结果。
+
+## 总结
+
+这节课从零开始，通过一个计算器示例，教会了如何用 `create_agent` 构建 ReAct Agent、理解消息流转机制、自定义状态、以及通过 `InjectedState` + `Command` 在工具中读写图状态。这些都是后续课程（TODO 工具、虚拟文件系统、子 Agent）的基础。

--- a/docs/1_todo.md
+++ b/docs/1_todo.md
@@ -1,0 +1,103 @@
+# 1_todo 笔记
+
+这是课程的**第一课**，核心主题是：**用 TODO 列表工具让 Agent 在长任务中保持专注**。
+
+## 背景问题：上下文腐化（Context Rot）
+
+Notebook 开篇引用了两个实际案例：
+- **Claude Code** 使用 `TodoWrite` 工具在执行前创建结构化任务列表
+- **Manus**（AI Agent 产品）的平均任务使用约 50 次工具调用
+
+当上下文窗口不断增长时，Agent 容易出现"上下文腐化"——遗忘早期目标、偏离主题。解决方案是**不断重写和更新 TODO 列表**，让目标始终出现在上下文末尾，帮助 Agent 保持聚焦。
+
+## 1. 状态定义（DeepAgentState）
+
+在 `state.py` 中定义了扩展状态，在 `AgentState` 基础上新增两个字段：
+
+```python
+class DeepAgentState(AgentState):
+    todos: NotRequired[list[Todo]]                         # TODO 列表
+    files: Annotated[NotRequired[dict[str, str]], file_reducer]  # 虚拟文件系统（下节课用）
+```
+
+其中 `Todo` 的结构为：
+
+```python
+class Todo(TypedDict):
+    content: str                                        # 任务描述
+    status: Literal["pending", "in_progress", "completed"]  # 状态
+```
+
+关键设计：`todos` 没有自定义 reducer，每次更新都是**全量覆盖**，这样 LLM 可以在推进过程中重新调整整个任务计划。
+
+## 2. TODO 工具描述（WRITE_TODOS_DESCRIPTION）
+
+提供给 LLM 的工具说明，核心规则：
+- **何时使用**：多步骤或复杂任务；用户提供多个任务时
+- **结构**：每个 todo 包含 content、status、id
+- **最佳实践**：同一时间只有一个 `in_progress` 任务；完成后立即标记；每次发送完整列表
+- **进度更新**：实时反映进度，不要批量标完；遇到阻塞时新增描述阻塞原因的任务
+
+## 3. 两个工具实现（todo_tools.py）
+
+### write_todos
+
+将 LLM 生成的 todo 列表写入 state：
+
+```python
+@tool
+def write_todos(todos: list[Todo], tool_call_id):
+    return Command(update={
+        "todos": todos,
+        "messages": [ToolMessage(f"Updated todo list to {todos}", tool_call_id=tool_call_id)]
+    })
+```
+
+- 参数 `todos` 由 LLM 生成
+- 用 `Command` 同时更新 state 中的 `todos` 和 `messages`
+- 写入动作本身也会作为 ToolMessage 出现在对话历史中，强化 LLM 的记忆
+
+### read_todos
+
+从 state 中读取当前 todo 列表：
+
+```python
+@tool
+def read_todos(state: Annotated[DeepAgentState, InjectedState], tool_call_id):
+    # 格式化输出，带状态 emoji：⏳ pending / 🔄 in_progress / ✅ completed
+```
+
+- 使用 `InjectedState` 注入 state（LLM 看不到这个参数）
+- 返回格式化的 todo 列表字符串
+
+## 4. Agent 构建与系统提示词
+
+系统提示词 `TODO_USAGE_INSTRUCTIONS` 规定了 Agent 的工作流程：
+
+1. 收到用户请求后，先用 `write_todos` 创建 TODO 计划
+2. 完成一个 TODO 后，用 `read_todos` 重新读取列表（**提醒自己当前进度**）
+3. 反思已完成的工作和剩余 TODO
+4. 标记任务为 completed，继续下一个
+5. 重复直到全部完成
+
+还有两个重要指令：
+- **任何请求都要先创建 TODO 计划**
+- **尽量将研究任务合并为单个 TODO**，减少跟踪负担
+
+## 5. 演示运行
+
+Notebook 使用一个 **mock 搜索工具**（返回固定的 MCP 协议介绍文本）来演示完整流程。用户问 "Give me a short summary of the Model Context Protocol (MCP)"，Agent 的执行流程大致为：
+
+1. LLM 调用 `write_todos` 创建计划（如：搜索 MCP -> 总结结果）
+2. LLM 调用 `web_search` 执行搜索
+3. LLM 调用 `read_todos` 回顾进度
+4. LLM 调用 `write_todos` 更新状态（标记完成）
+5. LLM 输出最终总结
+
+## 核心要点
+
+这节课的关键思想是**通过反复读写 TODO 列表来对抗上下文腐化**：
+- TODO 列表作为 Agent 的"工作记忆"存在于 state 中
+- 每次读写都会在 messages 中产生新的记录，确保目标始终在上下文窗口的"末尾"附近
+- 全量覆盖写入允许 Agent 动态调整计划
+- 这是从 Claude Code 和 Manus 等实际产品中提炼出的上下文工程（Context Engineering）技术


### PR DESCRIPTION
## Summary
- 为 `0_create_agent` notebook 添加中文解释文档 (`docs/0_create_agent.md`)
- 为 `1_todo` notebook 添加中文解释文档 (`docs/1_todo.md`)

Closes #3

## Test plan
- [x] Review `docs/0_create_agent.md` for accuracy
- [x] Review `docs/1_todo.md` for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)